### PR TITLE
Skip WebSetupWizardPluginInstaller on Magento Cloud Docker installations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "type": "project",
+  "name": "magento/composer-root-update-plugin",
   "description": "Git source for the Magento root update lookahead composer plugin",
   "license": [
     "OSL-3.0",

--- a/src/Magento/ComposerRootUpdatePlugin/Setup/WebSetupWizardPluginInstaller.php
+++ b/src/Magento/ComposerRootUpdatePlugin/Setup/WebSetupWizardPluginInstaller.php
@@ -32,7 +32,7 @@ class WebSetupWizardPluginInstaller
      * @var PackageUtils $pkgUtils
      */
     protected $pkgUtils;
-    
+
     /**
      * WebSetupWizardPluginInstaller constructor.
      *
@@ -166,7 +166,14 @@ class WebSetupWizardPluginInstaller
 
         if ($this->pkgUtils->findRequire($composer, PackageUtils::CLOUD_METAPACKAGE) !== false) {
             $this->console->log(
-                "Cloud installation detected, Not installing $packageName for the Web Setup Wizard",
+                "Cloud installation detected, not installing $packageName for the Web Setup Wizard",
+                Console::VERBOSE
+            );
+            return false;
+        }
+        if ($this->pkgUtils->findRequire($composer, PackageUtils::MAGENTO_CLOUD_DOCKER_PKG) !== false) {
+            $this->console->log(
+                "Magento Cloud Docker installation detected, not installing $packageName for the Web Setup Wizard",
                 Console::VERBOSE
             );
             return false;

--- a/src/Magento/ComposerRootUpdatePlugin/Utils/PackageUtils.php
+++ b/src/Magento/ComposerRootUpdatePlugin/Utils/PackageUtils.php
@@ -22,6 +22,7 @@ class PackageUtils
     const COMMERCE_PKG_EDITION = 'enterprise';
     const CLOUD_PKG_EDITION = 'cloud';
     const CLOUD_METAPACKAGE = 'magento/magento-cloud-metapackage';
+    const MAGENTO_CLOUD_DOCKER_PKG = 'magento/magento-cloud-docker';
 
     /**
      * @var Console $console


### PR DESCRIPTION
Add an additional check to skip WebSetupWizardPluginInstaller on Magento Cloud Docker installations.
